### PR TITLE
ds is not defined 오류 수정(youtube.js)

### DIFF
--- a/coronaboard-web/src/youtube.js
+++ b/coronaboard-web/src/youtube.js
@@ -15,7 +15,7 @@ function truncateText(text, maxLength) {
   if (text.length > maxLength) {
     return text.substr(0, maxLength) + '...';
   } else {
-    return ds;
+    return text;
   }
 }
 


### PR DESCRIPTION
안녕하세요.

책과 소스코드에서 youtube링크의 description 길이가 짧을 경우 return ds;가 수행되도록 되어있어 ds is not defiend 오류가 발생하였습니다.

maxLength를 초과하지 않을 경우 description 그대로인 text를 return하는 게 원래 작가님의 의도이신 것 같아서 return text;로 수정했습니다.